### PR TITLE
Update Dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,11 @@ repos:
   hooks:
   - id: flake8
 - repo: https://github.com/pycqa/isort
-  rev: 6.0.1
+  rev: 7.0.0
   hooks:
   - id: isort
 - repo: https://github.com/jazzband/pip-tools
-  rev: v7.5.0
+  rev: v7.5.1
   hooks:
     - id: pip-compile
       args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,22 @@
-amclient==1.5.0
+amclient==1.6.0
     # via -r requirements.in
 aws-assume-role-lib==2.10.0
     # via -r requirements.in
 bagit==1.9.0
     # via -r requirements.in
-boto3==1.40.42
+boto3==1.40.64
     # via
     #   -r requirements.in
     #   aws-assume-role-lib
-botocore==1.40.42
+botocore==1.40.64
     # via
     #   boto3
     #   s3transfer
-certifi==2025.8.3
+certifi==2025.10.5
     # via requests
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via requests
-idna==3.10
+idna==3.11
     # via requests
 jmespath==1.0.1
     # via


### PR DESCRIPTION
Merging with CI errors because of known issue with pip-tools conflict with pip that we expect to resolve in the future.